### PR TITLE
fix: overflow error in mobile

### DIFF
--- a/example/lib/pages/simple_editor.dart
+++ b/example/lib/pages/simple_editor.dart
@@ -63,7 +63,11 @@ class SimpleEditor extends StatelessWidget {
             return Column(
               children: [
                 Expanded(
-                  child: _buildEditor(context, editorState, scrollController),
+                  child: _buildMobileEditor(
+                    context,
+                    editorState,
+                    scrollController,
+                  ),
                 ),
                 if (Platform.isIOS || Platform.isAndroid)
                   _buildMobileToolbar(context, editorState),
@@ -76,6 +80,19 @@ class SimpleEditor extends StatelessWidget {
           );
         }
       },
+    );
+  }
+
+  Widget _buildMobileEditor(
+    BuildContext context,
+    EditorState editorState,
+    ScrollController? scrollController,
+  ) {
+    return AppFlowyEditor.custom(
+      editorStyle: const EditorStyle.mobile(),
+      editorState: editorState,
+      scrollController: scrollController,
+      blockComponentBuilders: standardBlockComponentBuilderMap,
     );
   }
 

--- a/lib/src/render/style/editor_style.dart
+++ b/lib/src/render/style/editor_style.dart
@@ -144,12 +144,15 @@ class EditorStyle extends ThemeExtension<EditorStyle> {
     Color? selectionColor,
     TextStyleConfiguration? textStyleConfiguration,
   }) : this(
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          backgroundColor: Colors.white,
-          cursorColor: const Color(0xFF00BCF0),
-          selectionColor: const Color.fromARGB(53, 111, 201, 231),
-          textStyleConfiguration:
-              textStyleConfiguration ?? const TextStyleConfiguration(),
+          padding: padding ?? const EdgeInsets.symmetric(horizontal: 20),
+          backgroundColor: backgroundColor ?? Colors.white,
+          cursorColor: cursorColor ?? const Color(0xFF00BCF0),
+          selectionColor:
+              selectionColor ?? const Color.fromARGB(53, 111, 201, 231),
+          textStyleConfiguration: textStyleConfiguration ??
+              const TextStyleConfiguration(
+                text: TextStyle(fontSize: 16, color: Colors.black),
+              ),
           selectionMenuBackgroundColor: null,
           selectionMenuItemTextColor: null,
           selectionMenuItemIconColor: null,


### PR DESCRIPTION
Reduce the padding in the editor style on mobile and set the mobile entry point in Editor

<img width="453" alt="image" src="https://github.com/LucasXu0/appflowy-editor/assets/14248245/a1605106-f3e2-4a7a-ae52-0245e6c20908">
